### PR TITLE
feat: Add backend for Matériel management

### DIFF
--- a/backend/civ/pom.xml
+++ b/backend/civ/pom.xml
@@ -51,6 +51,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/backend/civ/src/main/java/ma/project/civ/controllers/EnginMoteurController.java
+++ b/backend/civ/src/main/java/ma/project/civ/controllers/EnginMoteurController.java
@@ -1,0 +1,45 @@
+package ma.project.civ.controllers;
+
+import lombok.RequiredArgsConstructor;
+import ma.project.civ.dto.EnginMoteurDTO;
+import ma.project.civ.services.EnginMoteurService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/engin-moteurs")
+@RequiredArgsConstructor
+public class EnginMoteurController {
+
+    private final EnginMoteurService enginMoteurService;
+
+    @GetMapping
+    public ResponseEntity<List<EnginMoteurDTO>> getAllEnginMoteurs() {
+        return ResponseEntity.ok(enginMoteurService.findAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<EnginMoteurDTO> getEnginMoteurById(@PathVariable Long id) {
+        return ResponseEntity.ok(enginMoteurService.findById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<EnginMoteurDTO> createEnginMoteur(@Valid @RequestBody EnginMoteurDTO enginMoteurDTO) {
+        return new ResponseEntity<>(enginMoteurService.save(enginMoteurDTO), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<EnginMoteurDTO> updateEnginMoteur(@PathVariable Long id, @Valid @RequestBody EnginMoteurDTO enginMoteurDTO) {
+        return ResponseEntity.ok(enginMoteurService.update(id, enginMoteurDTO));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEnginMoteur(@PathVariable Long id) {
+        enginMoteurService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/civ/src/main/java/ma/project/civ/controllers/SiteProductionController.java
+++ b/backend/civ/src/main/java/ma/project/civ/controllers/SiteProductionController.java
@@ -1,0 +1,45 @@
+package ma.project.civ.controllers;
+
+import lombok.RequiredArgsConstructor;
+import ma.project.civ.dto.SiteProductionDTO;
+import ma.project.civ.services.SiteProductionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/site-productions")
+@RequiredArgsConstructor
+public class SiteProductionController {
+
+    private final SiteProductionService siteProductionService;
+
+    @GetMapping
+    public ResponseEntity<List<SiteProductionDTO>> getAllSiteProductions() {
+        return ResponseEntity.ok(siteProductionService.findAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SiteProductionDTO> getSiteProductionById(@PathVariable Long id) {
+        return ResponseEntity.ok(siteProductionService.findById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<SiteProductionDTO> createSiteProduction(@Valid @RequestBody SiteProductionDTO siteProductionDTO) {
+        return new ResponseEntity<>(siteProductionService.save(siteProductionDTO), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SiteProductionDTO> updateSiteProduction(@PathVariable Long id, @Valid @RequestBody SiteProductionDTO siteProductionDTO) {
+        return ResponseEntity.ok(siteProductionService.update(id, siteProductionDTO));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteSiteProduction(@PathVariable Long id) {
+        siteProductionService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/civ/src/main/java/ma/project/civ/controllers/materiel/LigneController.java
+++ b/backend/civ/src/main/java/ma/project/civ/controllers/materiel/LigneController.java
@@ -1,0 +1,45 @@
+package ma.project.civ.controllers.materiel;
+
+import lombok.RequiredArgsConstructor;
+import ma.project.civ.dto.materiel.LigneDTO;
+import ma.project.civ.services.materiel.LigneService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/lignes")
+@RequiredArgsConstructor
+public class LigneController {
+
+    private final LigneService ligneService;
+
+    @GetMapping
+    public ResponseEntity<List<LigneDTO>> getAllLignes() {
+        return ResponseEntity.ok(ligneService.findAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<LigneDTO> getLigneById(@PathVariable Long id) {
+        return ResponseEntity.ok(ligneService.findById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<LigneDTO> createLigne(@Valid @RequestBody LigneDTO ligneDTO) {
+        return new ResponseEntity<>(ligneService.save(ligneDTO), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<LigneDTO> updateLigne(@PathVariable Long id, @Valid @RequestBody LigneDTO ligneDTO) {
+        return ResponseEntity.ok(ligneService.update(id, ligneDTO));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteLigne(@PathVariable Long id) {
+        ligneService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/civ/src/main/java/ma/project/civ/dto/EnginMoteurDTO.java
+++ b/backend/civ/src/main/java/ma/project/civ/dto/EnginMoteurDTO.java
@@ -1,0 +1,16 @@
+package ma.project.civ.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class EnginMoteurDTO {
+    private Long id;
+    @NotBlank
+    private String serie;
+    @NotNull
+    private Integer numero;
+    @NotBlank
+    private String type;
+}

--- a/backend/civ/src/main/java/ma/project/civ/dto/SiteProductionDTO.java
+++ b/backend/civ/src/main/java/ma/project/civ/dto/SiteProductionDTO.java
@@ -1,0 +1,11 @@
+package ma.project.civ.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class SiteProductionDTO {
+    private Long id;
+    @NotBlank
+    private String nom;
+}

--- a/backend/civ/src/main/java/ma/project/civ/dto/materiel/LigneDTO.java
+++ b/backend/civ/src/main/java/ma/project/civ/dto/materiel/LigneDTO.java
@@ -1,0 +1,16 @@
+package ma.project.civ.dto.materiel;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class LigneDTO {
+    private Long id;
+    @NotBlank
+    private String origine;
+    @NotBlank
+    private String destination;
+    @NotNull
+    private Integer distance;
+}

--- a/backend/civ/src/main/java/ma/project/civ/entities/engin_moteur/EnginMoteurHabilitation.java
+++ b/backend/civ/src/main/java/ma/project/civ/entities/engin_moteur/EnginMoteurHabilitation.java
@@ -19,6 +19,9 @@ public abstract class EnginMoteurHabilitation {
     @Column(name = "nom_de_serie")
     private String serie;
 
+    @Column(name = "numero")
+    private Integer numero;
+
 
     public String getDiscriminatorValue() {
         DiscriminatorValue annotation = this.getClass().getAnnotation(DiscriminatorValue.class);

--- a/backend/civ/src/main/java/ma/project/civ/entities/materiel/Ligne.java
+++ b/backend/civ/src/main/java/ma/project/civ/entities/materiel/Ligne.java
@@ -1,0 +1,23 @@
+package ma.project.civ.entities.materiel;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Ligne {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String origine;
+    private String destination;
+    private Integer distance;
+}

--- a/backend/civ/src/main/java/ma/project/civ/mapper/EnginMoteurMapper.java
+++ b/backend/civ/src/main/java/ma/project/civ/mapper/EnginMoteurMapper.java
@@ -1,0 +1,39 @@
+package ma.project.civ.mapper;
+
+import ma.project.civ.dto.EnginMoteurDTO;
+import ma.project.civ.entities.engin_moteur.EnginMoteurHabilitation;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+import ma.project.civ.entities.engin_moteur.SerieE1400;
+import ma.project.civ.entities.engin_moteur.SerieZ2M;
+import org.mapstruct.ObjectFactory;
+import org.mapstruct.TargetType;
+
+@Mapper(componentModel = "spring")
+public interface EnginMoteurMapper extends GenericMapper<EnginMoteurHabilitation, EnginMoteurDTO> {
+
+    @Mappings({
+            @Mapping(source = "discriminatorValue", target = "type")
+    })
+    EnginMoteurDTO toDto(EnginMoteurHabilitation enginMoteurHabilitation);
+
+    @Mapping(target = "id", ignore = true)
+    EnginMoteurHabilitation toEntity(EnginMoteurDTO dto);
+
+    @ObjectFactory
+    default EnginMoteurHabilitation createEntity(EnginMoteurDTO dto, @TargetType Class<EnginMoteurHabilitation> type) {
+        if (dto == null || dto.getType() == null) {
+            return null;
+        }
+        switch (dto.getType()) {
+            case "SerieE1400":
+                return new SerieE1400();
+            case "SerieZ2M":
+                return new SerieZ2M();
+            default:
+                throw new IllegalArgumentException("Unknown engin moteur type: " + dto.getType());
+        }
+    }
+}

--- a/backend/civ/src/main/java/ma/project/civ/mapper/SiteProductionMapper.java
+++ b/backend/civ/src/main/java/ma/project/civ/mapper/SiteProductionMapper.java
@@ -1,0 +1,9 @@
+package ma.project.civ.mapper;
+
+import ma.project.civ.dto.SiteProductionDTO;
+import ma.project.civ.entities.organigramme.SiteProductionHabilitation;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface SiteProductionMapper extends GenericMapper<SiteProductionHabilitation, SiteProductionDTO> {
+}

--- a/backend/civ/src/main/java/ma/project/civ/mapper/materiel/LigneMapper.java
+++ b/backend/civ/src/main/java/ma/project/civ/mapper/materiel/LigneMapper.java
@@ -1,0 +1,10 @@
+package ma.project.civ.mapper.materiel;
+
+import ma.project.civ.dto.materiel.LigneDTO;
+import ma.project.civ.entities.materiel.Ligne;
+import ma.project.civ.mapper.GenericMapper;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface LigneMapper extends GenericMapper<Ligne, LigneDTO> {
+}

--- a/backend/civ/src/main/java/ma/project/civ/repositories/engin_moteur/EnginMoteurHabilitationRepository.java
+++ b/backend/civ/src/main/java/ma/project/civ/repositories/engin_moteur/EnginMoteurHabilitationRepository.java
@@ -3,8 +3,5 @@ package ma.project.civ.repositories.engin_moteur;
 import ma.project.civ.entities.engin_moteur.EnginMoteurHabilitation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.UUID;
-
 public interface EnginMoteurHabilitationRepository extends JpaRepository<EnginMoteurHabilitation, Long> {
-
 }

--- a/backend/civ/src/main/java/ma/project/civ/repositories/materiel/LigneRepository.java
+++ b/backend/civ/src/main/java/ma/project/civ/repositories/materiel/LigneRepository.java
@@ -1,0 +1,7 @@
+package ma.project.civ.repositories.materiel;
+
+import ma.project.civ.entities.materiel.Ligne;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LigneRepository extends JpaRepository<Ligne, Long> {
+}

--- a/backend/civ/src/main/java/ma/project/civ/services/EnginMoteurService.java
+++ b/backend/civ/src/main/java/ma/project/civ/services/EnginMoteurService.java
@@ -1,0 +1,13 @@
+package ma.project.civ.services;
+
+import ma.project.civ.dto.EnginMoteurDTO;
+
+import java.util.List;
+
+public interface EnginMoteurService {
+    List<EnginMoteurDTO> findAll();
+    EnginMoteurDTO findById(Long id);
+    EnginMoteurDTO save(EnginMoteurDTO enginMoteurDTO);
+    EnginMoteurDTO update(Long id, EnginMoteurDTO enginMoteurDTO);
+    void deleteById(Long id);
+}

--- a/backend/civ/src/main/java/ma/project/civ/services/EnginMoteurServiceImp.java
+++ b/backend/civ/src/main/java/ma/project/civ/services/EnginMoteurServiceImp.java
@@ -1,0 +1,58 @@
+package ma.project.civ.services;
+
+import lombok.RequiredArgsConstructor;
+import ma.project.civ.dto.EnginMoteurDTO;
+import ma.project.civ.entities.engin_moteur.EnginMoteurHabilitation;
+import ma.project.civ.mapper.EnginMoteurMapper;
+import ma.project.civ.repositories.engin_moteur.EnginMoteurHabilitationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class EnginMoteurServiceImp implements EnginMoteurService {
+
+    private final EnginMoteurHabilitationRepository enginMoteurRepository;
+    private final EnginMoteurMapper enginMoteurMapper;
+
+    @Override
+    public List<EnginMoteurDTO> findAll() {
+        return enginMoteurRepository.findAll()
+                .stream()
+                .map(enginMoteurMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public EnginMoteurDTO findById(Long id) {
+        EnginMoteurHabilitation enginMoteur = enginMoteurRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("EnginMoteur not found"));
+        return enginMoteurMapper.toDto(enginMoteur);
+    }
+
+    @Override
+    public EnginMoteurDTO save(EnginMoteurDTO enginMoteurDTO) {
+        EnginMoteurHabilitation enginMoteur = enginMoteurMapper.toEntity(enginMoteurDTO);
+        EnginMoteurHabilitation savedEnginMoteur = enginMoteurRepository.save(enginMoteur);
+        return enginMoteurMapper.toDto(savedEnginMoteur);
+    }
+
+    @Override
+    public EnginMoteurDTO update(Long id, EnginMoteurDTO enginMoteurDTO) {
+        EnginMoteurHabilitation existingEnginMoteur = enginMoteurRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("EnginMoteur not found"));
+
+        existingEnginMoteur.setSerie(enginMoteurDTO.getSerie());
+        existingEnginMoteur.setNumero(enginMoteurDTO.getNumero());
+
+        EnginMoteurHabilitation updatedEnginMoteur = enginMoteurRepository.save(existingEnginMoteur);
+        return enginMoteurMapper.toDto(updatedEnginMoteur);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        enginMoteurRepository.deleteById(id);
+    }
+}

--- a/backend/civ/src/main/java/ma/project/civ/services/SiteProductionService.java
+++ b/backend/civ/src/main/java/ma/project/civ/services/SiteProductionService.java
@@ -1,0 +1,13 @@
+package ma.project.civ.services;
+
+import ma.project.civ.dto.SiteProductionDTO;
+
+import java.util.List;
+
+public interface SiteProductionService {
+    List<SiteProductionDTO> findAll();
+    SiteProductionDTO findById(Long id);
+    SiteProductionDTO save(SiteProductionDTO siteProductionDTO);
+    SiteProductionDTO update(Long id, SiteProductionDTO siteProductionDTO);
+    void deleteById(Long id);
+}

--- a/backend/civ/src/main/java/ma/project/civ/services/SiteProductionServiceImp.java
+++ b/backend/civ/src/main/java/ma/project/civ/services/SiteProductionServiceImp.java
@@ -1,0 +1,55 @@
+package ma.project.civ.services;
+
+import lombok.RequiredArgsConstructor;
+import ma.project.civ.dto.SiteProductionDTO;
+import ma.project.civ.entities.organigramme.SiteProductionHabilitation;
+import ma.project.civ.mapper.SiteProductionMapper;
+import ma.project.civ.repositories.organigramme.SiteProductionHabilitationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SiteProductionServiceImp implements SiteProductionService {
+
+    private final SiteProductionHabilitationRepository siteProductionRepository;
+    private final SiteProductionMapper siteProductionMapper;
+
+    @Override
+    public List<SiteProductionDTO> findAll() {
+        return siteProductionRepository.findAll()
+                .stream()
+                .map(siteProductionMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public SiteProductionDTO findById(Long id) {
+        SiteProductionHabilitation siteProduction = siteProductionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("SiteProduction not found"));
+        return siteProductionMapper.toDto(siteProduction);
+    }
+
+    @Override
+    public SiteProductionDTO save(SiteProductionDTO siteProductionDTO) {
+        SiteProductionHabilitation siteProduction = siteProductionMapper.toEntity(siteProductionDTO);
+        SiteProductionHabilitation savedSiteProduction = siteProductionRepository.save(siteProduction);
+        return siteProductionMapper.toDto(savedSiteProduction);
+    }
+
+    @Override
+    public SiteProductionDTO update(Long id, SiteProductionDTO siteProductionDTO) {
+        SiteProductionHabilitation existingSiteProduction = siteProductionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("SiteProduction not found"));
+        existingSiteProduction.setNom(siteProductionDTO.getNom());
+        SiteProductionHabilitation updatedSiteProduction = siteProductionRepository.save(existingSiteProduction);
+        return siteProductionMapper.toDto(updatedSiteProduction);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        siteProductionRepository.deleteById(id);
+    }
+}

--- a/backend/civ/src/main/java/ma/project/civ/services/materiel/LigneService.java
+++ b/backend/civ/src/main/java/ma/project/civ/services/materiel/LigneService.java
@@ -1,0 +1,13 @@
+package ma.project.civ.services.materiel;
+
+import ma.project.civ.dto.materiel.LigneDTO;
+
+import java.util.List;
+
+public interface LigneService {
+    List<LigneDTO> findAll();
+    LigneDTO findById(Long id);
+    LigneDTO save(LigneDTO ligneDTO);
+    LigneDTO update(Long id, LigneDTO ligneDTO);
+    void deleteById(Long id);
+}

--- a/backend/civ/src/main/java/ma/project/civ/services/materiel/LigneServiceImp.java
+++ b/backend/civ/src/main/java/ma/project/civ/services/materiel/LigneServiceImp.java
@@ -1,0 +1,57 @@
+package ma.project.civ.services.materiel;
+
+import lombok.RequiredArgsConstructor;
+import ma.project.civ.dto.materiel.LigneDTO;
+import ma.project.civ.entities.materiel.Ligne;
+import ma.project.civ.mapper.materiel.LigneMapper;
+import ma.project.civ.repositories.materiel.LigneRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LigneServiceImp implements LigneService {
+
+    private final LigneRepository ligneRepository;
+    private final LigneMapper ligneMapper;
+
+    @Override
+    public List<LigneDTO> findAll() {
+        return ligneRepository.findAll()
+                .stream()
+                .map(ligneMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public LigneDTO findById(Long id) {
+        Ligne ligne = ligneRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Ligne not found"));
+        return ligneMapper.toDto(ligne);
+    }
+
+    @Override
+    public LigneDTO save(LigneDTO ligneDTO) {
+        Ligne ligne = ligneMapper.toEntity(ligneDTO);
+        Ligne savedLigne = ligneRepository.save(ligne);
+        return ligneMapper.toDto(savedLigne);
+    }
+
+    @Override
+    public LigneDTO update(Long id, LigneDTO ligneDTO) {
+        Ligne existingLigne = ligneRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Ligne not found"));
+        existingLigne.setOrigine(ligneDTO.getOrigine());
+        existingLigne.setDestination(ligneDTO.getDestination());
+        existingLigne.setDistance(ligneDTO.getDistance());
+        Ligne updatedLigne = ligneRepository.save(existingLigne);
+        return ligneMapper.toDto(updatedLigne);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        ligneRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
This commit implements the backend for the 'Matériel' section, which includes management for 'Engin Moteur', 'Site Production', and 'Ligne'.

For each of these features, the following has been added:
- A REST controller with CRUD endpoints.
- A service layer to handle business logic.
- A DTO for data transfer.
- A MapStruct mapper for mapping between entities and DTOs.
- A repository for database operations.
- A new 'Ligne' entity has been created.
- The existing 'EnginMoteurHabilitation' entity has been updated to include the 'numero' field.
- The existing 'SiteProductionHabilitation' entity has been used for 'Site Production' management.
- Validation has been added to the DTOs and controllers.